### PR TITLE
Configure arrow back on detail screen

### DIFF
--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/detail/ShowDetailFragment.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/detail/ShowDetailFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import dagger.hilt.android.AndroidEntryPoint
 import io.parrotsoftware.qatest.databinding.FragmentShowDetailBinding
+import io.parrotsoftware.qatest.utils.supportActionBar
 
 @AndroidEntryPoint
 class ShowDetailFragment : Fragment() {
@@ -16,6 +17,11 @@ class ShowDetailFragment : Fragment() {
     private lateinit var binding: FragmentShowDetailBinding
 
     private val args : ShowDetailFragmentArgs by navArgs()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportActionBar()?.setDisplayHomeAsUpEnabled(true)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListFragment.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListFragment.kt
@@ -7,7 +7,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -18,6 +17,7 @@ import io.parrotsoftware.qatest.utils.observe
 import io.parrotsoftware.qatest.utils.toast
 import io.parrotsoftware.qatest.databinding.FragmentListBinding
 import io.parrotsoftware.qatest.utils.menuProvider
+import io.parrotsoftware.qatest.utils.supportActionBar
 
 @AndroidEntryPoint
 class ListFragment :
@@ -32,9 +32,9 @@ class ListFragment :
         CategoryController(this)
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        showSupportActionBar()
+    override fun onResume() {
+        super.onResume()
+        setSupportActionBar()
     }
 
     override fun onCreateView(
@@ -77,8 +77,11 @@ class ListFragment :
         return false
     }
 
-    private fun showSupportActionBar() {
-        (requireActivity() as AppCompatActivity).supportActionBar?.show()
+    private fun setSupportActionBar() {
+        supportActionBar()?.apply {
+            show()
+            setDisplayHomeAsUpEnabled(false)
+        }
     }
 
     private fun onViewState(state: ListViewState?) {

--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/main/MainActivity.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/main/MainActivity.kt
@@ -1,7 +1,8 @@
 package io.parrotsoftware.qatest.presentation.main
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.coroutineScope
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +20,14 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         configureSplashScreen()
         setContentView(R.layout.main_activity)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressedDispatcher.onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     private fun configureSplashScreen() {

--- a/app/src/main/java/io/parrotsoftware/qatest/utils/FragmentExt.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/utils/FragmentExt.kt
@@ -1,5 +1,6 @@
 package io.parrotsoftware.qatest.utils
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
@@ -19,3 +20,5 @@ fun <T : Any, L : LiveData<T>?> LifecycleOwner.removeObservers(liveData: L) {
 
 fun Fragment.menuProvider(menuProvider: MenuProvider) =
     (requireActivity() as MenuHost).addMenuProvider(menuProvider, viewLifecycleOwner, Lifecycle.State.RESUMED)
+
+fun Fragment.supportActionBar() = (activity as AppCompatActivity).supportActionBar


### PR DESCRIPTION
# :clipboard: Summary
The main goal is add arrow back in `ShowDetailScreen`

## :cyclone: Changes
- `setDisplayHomeAsUpEnabled` in true 
- overrided `onOptionsItemSelected` method in `MainActivity`
- Added extension to get supportActionBar

## :art: UI changes
_Screenshots, images and videos showcasing_
No Ui changes

## :pushpin: Related ticket(s)
* No JIRA ticket related

## :writing_hand: How could this be manually tested
Validate that arrow back works well in ShowDetailFragment
