### PR TITLE
Add unauthorized validation to logout when session expires

### DIFF
--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListFragment.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListFragment.kt
@@ -66,13 +66,7 @@ class ListFragment :
 
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         when (menuItem.itemId) {
-            R.id.menu_logout -> {
-                viewModel.logout().also {
-                    findNavController().navigate(
-                        ListFragmentDirections.actionListFragmentToLoginFragment()
-                    )
-                }
-            }
+            R.id.menu_logout -> { logout() }
         }
         return false
     }
@@ -84,16 +78,28 @@ class ListFragment :
         }
     }
 
+    private fun logout() {
+        viewModel.logout().also {
+            findNavController().navigate(
+                ListFragmentDirections.actionListFragmentToLoginFragment()
+            )
+        }
+    }
+
     private fun onViewState(state: ListViewState?) {
         when (state) {
             ListViewState.ErrorLoadingItems -> {
-                requireContext().toast("Error al cargar los productos")
+                requireContext().toast(R.string.error_load_products)
             }
             is ListViewState.ItemsLoaded -> {
                 categoryController.categories = state.categories
             }
             ListViewState.ErrorUpdatingItem -> {
-                requireContext().toast("Error al actualizar el producto")
+                requireContext().toast(R.string.error_update_product)
+            }
+            ListViewState.InvalidSession -> {
+                requireContext().toast(R.string.error_session_expired)
+                logout()
             }
             else -> {}
         }

--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListViewModel.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListViewModel.kt
@@ -83,7 +83,10 @@ class ListViewModel @Inject constructor(
             )
 
             if (response.isError) {
-                _viewState.value = ListViewState.ErrorUpdatingItem
+                _viewState.value = when (response.error?.code) {
+                    UNAUTHORIZED -> ListViewState.InvalidSession
+                    else -> ListViewState.ErrorUpdatingItem
+                }
                 return@launch
             }
 
@@ -132,5 +135,9 @@ class ListViewModel @Inject constructor(
         viewModelScope.launch {
             logoutUseCase()
         }
+    }
+
+    companion object {
+        private const val UNAUTHORIZED = "401"
     }
 }

--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListViewState.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/list/ListViewState.kt
@@ -6,6 +6,7 @@ sealed class ListViewState {
     object ErrorLoadingItems : ListViewState()
     object ErrorUpdatingItem : ListViewState()
     object ItemUpdated : ListViewState()
+    object InvalidSession : ListViewState()
     class ItemsLoaded(val categories: List<ExpandableCategory>) : ListViewState()
 
 }

--- a/app/src/main/java/io/parrotsoftware/qatest/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/presentation/login/LoginFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
+import io.parrotsoftware.qatest.R
 import io.parrotsoftware.qatest.databinding.FragmentLoginBinding
 import io.parrotsoftware.qatest.utils.observe
 import io.parrotsoftware.qatest.utils.toast
@@ -47,7 +48,7 @@ class LoginFragment : Fragment() {
     private fun onViewState(state: LoginViewState?) {
         when (state) {
             LoginViewState.LoginError -> {
-                requireContext().toast("Error al iniciar sesión")
+                requireContext().toast(R.string.error_login)
             }
             LoginViewState.LoginSuccess -> {
                 findNavController().navigate(

--- a/app/src/main/java/io/parrotsoftware/qatest/utils/ContextExt.kt
+++ b/app/src/main/java/io/parrotsoftware/qatest/utils/ContextExt.kt
@@ -2,10 +2,11 @@ package io.parrotsoftware.qatest.utils
 
 import android.content.Context
 import android.widget.Toast
+import androidx.annotation.StringRes
 
-fun Context.toast(message: CharSequence, isLengthShort: Boolean = true) =
+fun Context.toast(@StringRes resource: Int, isLengthShort: Boolean = true) =
     Toast.makeText(
-        this, message, if (isLengthShort) {
+        this, resource, if (isLengthShort) {
             Toast.LENGTH_SHORT
         } else {
             Toast.LENGTH_LONG

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,10 @@
     <string name="detail_available">Producto disponible</string>
     <string name="detail_unavailable">Producto no disponible</string>
 
+    <!-- Errors -->
+    <string name="error_session_expired">Tu sesión ha expirado</string>
+    <string name="error_update_product">Error al actualizar el producto</string>
+    <string name="error_load_products">Error al cargar los productos</string>
+    <string name="error_login">Error al iniciar sesión</string>
+
 </resources>


### PR DESCRIPTION
# :clipboard: Summary
The main goal is handle 401 error in setUpdateProduct service, in get products service is not needed because first time that we login, products are saved in database and if session expired or fail service the products were taken from database.

## :cyclone: Changes
- Error message were migrated to strings.xml
- Modified toast extension to receive string id
- Added new state `InvalidSession` in `ListViewState`
- Set `_viewState` with `ListViewState.InvalidSession` when error code is 401

## :art: UI changes
_Screenshots, images and videos showcasing_
No UI changes.

## :pushpin: Related ticket(s)
* No JIRA ticket related

## :writing_hand: How could this be manually tested
Wait until session expires and try to update product in list.
